### PR TITLE
 feat(base-button-test): add basic tests for baseButton

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -4,6 +4,7 @@
   "rules": {
     "header-max-length": [0],
     "type-enum": [2, "always", ["feat", "fix", "refactor", "docs", "style", "test", "ci", "core", "chore", "perf"]],
-    "subject-case": [2, "never", ["sentence-case", "start-case", "pascal-case", "upper-case"]]
+    "subject-case": [2, "never", ["sentence-case", "start-case", "pascal-case", "upper-case"]],
+    "body-max-line-length": [0]
   }
 }

--- a/src/components/baseButton/BaseButton.spec.tsx
+++ b/src/components/baseButton/BaseButton.spec.tsx
@@ -20,7 +20,7 @@ describe("BaseButton component", () => {
     expect(buttonElement).toBeInTheDocument();
   });
 
-  it("should call the onClick handler once when clicked", async () => {
+  it("should call the onClick handler when clicked", async () => {
     const user = userEvent.setup();
     await user.click(buttonElement);
     expect(defaultProps.onClick).toBeCalledTimes(1);

--- a/src/components/baseButton/BaseButton.spec.tsx
+++ b/src/components/baseButton/BaseButton.spec.tsx
@@ -14,7 +14,7 @@ describe("BaseButton component", () => {
     buttonElement = buttonComponent.getByRole("button", { name: defaultProps.text });
   });
 
-  it("should be present in the DOM when rendered", () => {
+  it("should be in the DOM", () => {
     expect(buttonElement).toBeInTheDocument();
   });
 

--- a/src/components/baseButton/BaseButton.spec.tsx
+++ b/src/components/baseButton/BaseButton.spec.tsx
@@ -10,6 +10,8 @@ describe("BaseButton component", () => {
   let buttonElement: HTMLElement;
 
   beforeEach(() => {
+    // reset the mock
+    jest.clearAllMocks();
     const buttonComponent = render(<BaseButton text={defaultProps.text} onClick={defaultProps.onClick}></BaseButton>);
     buttonElement = buttonComponent.getByRole("button", { name: defaultProps.text });
   });
@@ -22,5 +24,12 @@ describe("BaseButton component", () => {
     const user = userEvent.setup();
     await user.click(buttonElement);
     expect(defaultProps.onClick).toBeCalledTimes(1);
+  });
+
+  it("should call the onClick handler twice when clicked twice", async () => {
+    const user = userEvent.setup();
+    await user.click(buttonElement);
+    await user.click(buttonElement);
+    expect(defaultProps.onClick).toBeCalledTimes(2);
   });
 });

--- a/src/components/baseButton/BaseButton.spec.tsx
+++ b/src/components/baseButton/BaseButton.spec.tsx
@@ -1,0 +1,26 @@
+import { render, userEvent } from "~__test__/test-utils";
+import { BaseButton } from "~components/baseButton";
+
+describe("BaseButton component", () => {
+  const defaultProps = {
+    text: "Hello World",
+    onClick: jest.fn(),
+  };
+
+  let buttonElement: HTMLElement;
+
+  beforeEach(() => {
+    const buttonComponent = render(<BaseButton text={defaultProps.text} onClick={defaultProps.onClick}></BaseButton>);
+    buttonElement = buttonComponent.getByRole("button", { name: defaultProps.text });
+  });
+
+  it("should be present in the DOM when rendered", () => {
+    expect(buttonElement).toBeInTheDocument();
+  });
+
+  it("should call the onClick handler once when clicked", async () => {
+    const user = userEvent.setup();
+    await user.click(buttonElement);
+    expect(defaultProps.onClick).toBeCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- the base button must be present when rendered correctly in the DOM
- the base button must correctly dispatch it's onClick handler

## Trello Card
- Closes [TC#10](https://trello.com/c/2S7RlXnm/10-1-etq-dev-je-cr%C3%A9e-un-test-pour-le-composant-g%C3%A9n%C3%A9rique-basebutton)

## Figma Reference
- [Landing Page](https://www.figma.com/design/QC1LbA6qGVTWA3ZsbYvnHS/Theodo_Dojo?t=Uc1CVlA25vb3fqAm-0)