### PR TITLE
feat(primary-button): create primary button 

### DIFF
--- a/src/app/muiThemeProvider/mui-theme-fonts.ts
+++ b/src/app/muiThemeProvider/mui-theme-fonts.ts
@@ -1,0 +1,99 @@
+const neuePath = "/assets/fonts/neue-haas-display";
+
+export const NeueFonts = `
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayLight.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: italic;
+  font-weight: 400;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayLightItalic.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: normal;
+  font-weight: 100;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayXXThin.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: italic;
+  font-weight: 100;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayXXThinItalic.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: normal;
+  font-weight: 200;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayXThin.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: italic;
+  font-weight: 200;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayXThinItalic.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayThin.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: italic;
+  font-weight: 300;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayThinItalic.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: normal;
+  font-weight: 500;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayRoman.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: italic;
+  font-weight: 500;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayRomanItalic.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayMediu.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: italic;
+  font-weight: 600;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayMediumItalic.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayBold.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: italic;
+  font-weight: 700;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayBoldItalic.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: normal;
+  font-weight: 900;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayBlack.woff') format('woff');
+}
+@font-face {
+  font-family: 'Neue Haas Grotesk Display Pro';
+  font-style: italic;
+  font-weight: 900;
+  src: local('Neue Haas Grotesk Display Pro'), url('${neuePath}/NeueHaasDisplayBlackItalic.woff') format('woff');
+}`;

--- a/src/app/muiThemeProvider/mui-theme.ts
+++ b/src/app/muiThemeProvider/mui-theme.ts
@@ -1,3 +1,5 @@
+import { NeueFonts } from "~app/muiThemeProvider/mui-theme-fonts";
+
 import type { Theme } from "@mui/material/styles";
 import { createTheme } from "@mui/material/styles";
 
@@ -47,11 +49,17 @@ const muiTheme: Theme = createTheme({
     },
   },
   typography: {
-    fontFamily: `"Neue Haas Grotesk Display Pro", "Arial", sans-serif`,
+    fontFamily: ["Neue Haas Grotesk Display Pro", "Arial", "sans-serif"].join(","),
     fontWeightLight: 300,
     fontWeightRegular: 400,
     fontWeightMedium: 500,
     fontWeightBold: 700,
+  },
+
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: NeueFonts,
+    },
   },
 });
 export default muiTheme;

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -19,10 +19,6 @@ const PlaygroundPage: React.FC = () => {
   const count = useAppSelector(selectCount);
   const [incrementAmount, setIncrementAmount] = React.useState<number>(0);
 
-  const emptyFunction = () => {
-    return null;
-  };
-
   return (
     <>
       <div>
@@ -30,14 +26,14 @@ const PlaygroundPage: React.FC = () => {
         <BaseButton
           text="signIn"
           onClick={() => {
-            emptyFunction();
+            //
           }}
         />
         {/* BaseButton with text, onClick, and icon */}
         <BaseButton
           text="signUp"
           onClick={() => {
-            emptyFunction();
+            //
           }}
           icon={<ArrowRightIcon />}
         />
@@ -45,7 +41,7 @@ const PlaygroundPage: React.FC = () => {
         <BaseButton
           text=""
           onClick={() => {
-            emptyFunction();
+            //
           }}
           icon={<ArrowRightIcon />}
         />
@@ -55,7 +51,7 @@ const PlaygroundPage: React.FC = () => {
         <PrimaryButton
           text="Sign in"
           onClick={() => {
-            emptyFunction();
+            //
           }}
         />
       </div>

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "~components/elements/styled";
 import { ArrowRightIcon } from "~components/icons/arrow";
 import Banner3S from "~components/landing/banner3s";
 import { LandingEmotionButton } from "~components/landing/LandingEmotionButton";
+import { PrimaryButton } from "~components/primaryButton";
 import txKeys from "~i18n/translations";
 import { useTranslation } from "~i18n/useTranslation";
 import { useAppDispatch, useAppSelector } from "~store";
@@ -47,6 +48,15 @@ const PlaygroundPage: React.FC = () => {
             emptyFunction();
           }}
           icon={<ArrowRightIcon />}
+        />
+      </div>
+      <div>
+        {/* PrimaryButton */}
+        <PrimaryButton
+          text="Sign in"
+          onClick={() => {
+            emptyFunction();
+          }}
         />
       </div>
       <LandingEmotionButton />

--- a/src/components/baseButton/BaseButton.tsx
+++ b/src/components/baseButton/BaseButton.tsx
@@ -1,14 +1,15 @@
 import { BaseStyledButton } from "~components/baseButton/BaseButton.style";
 
 interface BaseButtonProps {
+  className?: string;
   text: string;
   onClick: () => void;
   icon?: JSX.Element;
 }
 
-export function BaseButton({ text, onClick, icon }: BaseButtonProps): JSX.Element {
+export function BaseButton({ className, text, onClick, icon }: BaseButtonProps): JSX.Element {
   return (
-    <BaseStyledButton onClick={onClick}>
+    <BaseStyledButton className={className ?? ""} onClick={onClick}>
       {icon}
       {text}
     </BaseStyledButton>

--- a/src/components/primaryButton/PrimaryButton.style.ts
+++ b/src/components/primaryButton/PrimaryButton.style.ts
@@ -1,0 +1,14 @@
+import { BaseButton } from "~components/baseButton";
+
+import { styled } from "@mui/material";
+
+export const StyledPrimaryButton = styled(BaseButton)(({ theme }) => ({
+  backgroundColor: "white",
+  color: theme.palette.secondary.main,
+  "&:hover": {
+    backgroundColor: theme.palette.primary.light,
+    color: theme.palette.primary.contrastText,
+  },
+  fontWeight: 600,
+  fontFamily: "Neue Haas Grotesk Display Pro",
+}));

--- a/src/components/primaryButton/PrimaryButton.style.ts
+++ b/src/components/primaryButton/PrimaryButton.style.ts
@@ -9,6 +9,6 @@ export const StyledPrimaryButton = styled(BaseButton)(({ theme }) => ({
     backgroundColor: theme.palette.primary.light,
     color: theme.palette.primary.contrastText,
   },
-  fontWeight: 600,
-  fontFamily: "Neue Haas Grotesk Display Pro",
+  fontWeight: theme.typography.fontWeightBold,
+  fontFamily: theme.typography.fontFamily,
 }));

--- a/src/components/primaryButton/PrimaryButton.tsx
+++ b/src/components/primaryButton/PrimaryButton.tsx
@@ -1,0 +1,10 @@
+import { StyledPrimaryButton } from "~components/primaryButton/PrimaryButton.style";
+
+interface PrimaryButtonProps {
+  text: string;
+  onClick: () => void;
+}
+
+export function PrimaryButton({ text, onClick }: PrimaryButtonProps): JSX.Element {
+  return <StyledPrimaryButton text={text} onClick={onClick} />;
+}

--- a/src/components/primaryButton/index.ts
+++ b/src/components/primaryButton/index.ts
@@ -1,0 +1,1 @@
+export { PrimaryButton } from "./PrimaryButton";


### PR DESCRIPTION
## Summary
- add the primary button that's derived from base button
- fixes base button's classname not allowing style override
- add the fonts used in figma

## Trello Card
- Closes [TC#49](https://trello.com/c/CEMaeWp6/49-1-etq-dev-je-veux-cr%C3%A9er-un-composant-g%C3%A9n%C3%A9rique-primarybutton)

## Figma Reference
- [Landing Page](https://www.figma.com/design/QC1LbA6qGVTWA3ZsbYvnHS/Theodo_Dojo?t=Uc1CVlA25vb3fqAm-0)