### PR TITLE
chore(update-react-fc-to-fc): update react functional component to regular functions

### DIFF
--- a/src/__plop__/ComponentReact.hbs
+++ b/src/__plop__/ComponentReact.hbs
@@ -1,7 +1,3 @@
-import type { FC } from "react";
-
-const {{pascalCase name}}: FC = () => {
+export default function {{pascalCase name}}(): JSX.Element {
   return <div>{{name}}</div>;
 };
-
-export default {{pascalCase name}};

--- a/src/__plop__/Page.hbs
+++ b/src/__plop__/Page.hbs
@@ -1,4 +1,4 @@
-const {{pascalCase name}}Page: React.FC = () => {
+export default function {{pascalCase name}}Page(): JSX.Element {
   return (
     <div>
       <NextSeo title="{{pascalCase name}}" />
@@ -6,5 +6,3 @@ const {{pascalCase name}}Page: React.FC = () => {
     </div>
   );
 };
-
-export default {{pascalCase name}}Page;

--- a/src/app/about/layout.tsx
+++ b/src/app/about/layout.tsx
@@ -1,10 +1,8 @@
-const AboutLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
+export default function AboutLayout({ children }: React.PropsWithChildren): JSX.Element {
   return (
     <>
       <h1>About</h1>
       {children}
     </>
   );
-};
-
-export default AboutLayout;
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,12 +6,11 @@ export const metadata: Metadata = {
   title: "About",
 };
 
-const AboutPage: React.FC = () => {
+export default function AboutPage(): JSX.Element {
   return (
     <div>
       <h1>{SITE_CONFIG.title}</h1>
       <h2>{SITE_CONFIG.description}</h2>
     </div>
   );
-};
-export default AboutPage;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import "../styles/globals.css";
 
+import React from "react";
+
 import { SITE_CONFIG } from "~config/site";
 
 import { Providers } from "./providers";
@@ -28,7 +30,7 @@ export const metadata: Metadata = {
   },
 };
 
-const RootLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
+export default function RootLayout({ children }: React.PropsWithChildren): JSX.Element {
   return (
     <html lang="en">
       <body>
@@ -38,6 +40,4 @@ const RootLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
       </body>
     </html>
   );
-};
-
-export default RootLayout;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,8 +6,6 @@ export const metadata: Metadata = {
   title: "Theodo Dojo",
 };
 
-const HomePage: React.FC = () => {
+export default function HomePage(): JSX.Element {
   return <Home />;
-};
-
-export default HomePage;
+}

--- a/src/app/playground/layout.tsx
+++ b/src/app/playground/layout.tsx
@@ -4,7 +4,7 @@ export const metadata = {
   title: "Playground",
 };
 
-const PlaygroundLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
+export default function PlaygroundLayout({ children }: React.PropsWithChildren): JSX.Element {
   return (
     <div>
       <h1>{SITE_CONFIG.title}</h1>
@@ -14,6 +14,4 @@ const PlaygroundLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
       {children}
     </div>
   );
-};
-
-export default PlaygroundLayout;
+}

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from "~i18n/useTranslation";
 import { useAppDispatch, useAppSelector } from "~store";
 import { decrement, increment, incrementByAmount, selectCount } from "~store/counter/slice";
 
-const PlaygroundPage: React.FC = () => {
+export default function PlaygroundPage(): JSX.Element {
   const translate = useTranslation();
 
   const dispatch = useAppDispatch();
@@ -80,6 +80,4 @@ const PlaygroundPage: React.FC = () => {
       </div>
     </>
   );
-};
-
-export default PlaygroundPage;
+}

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -5,8 +5,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Posts",
 };
-const PostsPage: React.FC = () => {
-  return <PostsContainer />;
-};
 
-export default PostsPage;
+export default function PostsPage(): JSX.Element {
+  return <PostsContainer />;
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -14,7 +14,7 @@ import { CssBaseline } from "@mui/material";
 import { SnackbarProvider } from "notistack";
 import { QueryClientProvider } from "react-query";
 
-export const Providers: React.FC<React.PropsWithChildren> = ({ children }) => {
+export function Providers({ children }: React.PropsWithChildren): JSX.Element {
   return (
     <RootStyleRegistry>
       <StrictMode>
@@ -31,4 +31,4 @@ export const Providers: React.FC<React.PropsWithChildren> = ({ children }) => {
       </StrictMode>
     </RootStyleRegistry>
   );
-};
+}

--- a/src/app/styleRegistry.tsx
+++ b/src/app/styleRegistry.tsx
@@ -10,7 +10,7 @@ import { useServerInsertedHTML } from "next/navigation";
  * @see https://nextjs.org/docs/app/building-your-application/styling/css-in-js#configuring-css-in-js-in-app
  * @see https://github.com/emotion-js/emotion/issues/2928
  */
-export const RootStyleRegistry: React.FC<React.PropsWithChildren> = ({ children }) => {
+export function RootStyleRegistry({ children }: React.PropsWithChildren): JSX.Element {
   const [emotionCache] = useState(() => {
     const cache = createCache({ key: "css" });
     cache.compat = true;
@@ -30,4 +30,4 @@ export const RootStyleRegistry: React.FC<React.PropsWithChildren> = ({ children 
   });
 
   return <CacheProvider value={emotionCache}>{children}</CacheProvider>;
-};
+}

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -6,9 +6,8 @@ import txKeys from "~i18n/translations";
 
 import { Box, Stack } from "@mui/material";
 import theodoLogo from "public/assets/theodo.png";
-import type { FC } from "react";
 
-const Home: FC = () => {
+export default function Home(): JSX.Element {
   return (
     <Box>
       <BackgroundContainer className="landing">
@@ -25,6 +24,4 @@ const Home: FC = () => {
       </BackgroundContainer>
     </Box>
   );
-};
-
-export default Home;
+}

--- a/src/components/landing/ChangeLanguageButton.tsx
+++ b/src/components/landing/ChangeLanguageButton.tsx
@@ -7,7 +7,7 @@ import { Language } from "~i18n/types";
 import { useLanguage } from "~i18n/useLanguage";
 import { fireAndNotifyOnError } from "~utils/notistackRef";
 
-const ChangeLanguageButton: React.FC = () => {
+export default function ChangeLanguageButton(): JSX.Element {
   const [language, changeLanguage] = useLanguage();
 
   return (
@@ -18,5 +18,4 @@ const ChangeLanguageButton: React.FC = () => {
       <TranslateMessage txKey={txKeys.common.changeLanguage} />
     </button>
   );
-};
-export default ChangeLanguageButton;
+}

--- a/src/components/landing/LandingEmotionButton.tsx
+++ b/src/components/landing/LandingEmotionButton.tsx
@@ -5,7 +5,7 @@ import { Button } from "~components/elements/styled";
 import txKeys from "~i18n/translations";
 import { useTranslation } from "~i18n/useTranslation";
 
-export const LandingEmotionButton: React.FC = () => {
+export function LandingEmotionButton(): JSX.Element {
   const translate = useTranslation();
   return <Button>{translate(txKeys.common.styledButton)}</Button>;
-};
+}

--- a/src/components/landing/banner3s.tsx
+++ b/src/components/landing/banner3s.tsx
@@ -7,18 +7,18 @@ interface Banner3SProps {
   doc: string;
 }
 
-const Banner3S: React.FC<React.PropsWithChildren<Banner3SProps>> = ({ title, doc, children }) => (
-  <div className="xl:w-1/4 lg:w-1/2 md:w-full px-8 py-6 border-l-2 border-gray-200 border-opacity-60 flex flex-col justify-between">
-    <section>
-      <h2 className="text-lg sm:text-xl text-gray-900 font-medium title-font mb-2">{title}</h2>
-      <p className="leading-relaxed text-base mb-4">{children}</p>
-    </section>
+export default function Banner3S({ title, doc, children }: React.PropsWithChildren<Banner3SProps>): JSX.Element {
+  return (
+    <div className="xl:w-1/4 lg:w-1/2 md:w-full px-8 py-6 border-l-2 border-gray-200 border-opacity-60 flex flex-col justify-between">
+      <section>
+        <h2 className="text-lg sm:text-xl text-gray-900 font-medium title-font mb-2">{title}</h2>
+        <p className="leading-relaxed text-base mb-4">{children}</p>
+      </section>
 
-    <a href={doc} target="_blank" rel="noreferrer" className="text-red-500 inline-flex items-center">
-      Learn More
-      <ArrowRightIcon />
-    </a>
-  </div>
-);
-
-export default Banner3S;
+      <a href={doc} target="_blank" rel="noreferrer" className="text-red-500 inline-flex items-center">
+        Learn More
+        <ArrowRightIcon />
+      </a>
+    </div>
+  );
+}

--- a/src/components/posts/PostsContainer.tsx
+++ b/src/components/posts/PostsContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { usePostMutation, usePostsQuery } from "~hooks/posts";
 
-export const PostsContainer: React.FC = () => {
+export function PostsContainer(): JSX.Element {
   const { loading, posts } = usePostsQuery();
   const { mutate: savePost } = usePostMutation();
 
@@ -26,4 +26,4 @@ export const PostsContainer: React.FC = () => {
       </div>
     </>
   );
-};
+}

--- a/src/i18n/TranslateMessage.tsx
+++ b/src/i18n/TranslateMessage.tsx
@@ -13,9 +13,7 @@ interface ITranslateMessageProps {
   shouldUnescape?: boolean;
 }
 
-const TranslateMessage: React.FC<ITranslateMessageProps> = ({ txKey, ...props }) => {
+export default function TranslateMessage({ txKey, ...props }: ITranslateMessageProps): JSX.Element {
   const translation = useTranslation();
   return <Trans t={translation.t} i18nKey={txKey} {...props} />;
-};
-
-export default TranslateMessage;
+}

--- a/src/store/provider.tsx
+++ b/src/store/provider.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
+import React from "react";
 
 import { store } from "./configure";
 
 import { Provider } from "react-redux";
 
-export const StoreProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+export function StoreProvider({ children }: React.PropsWithChildren): JSX.Element {
   return <Provider store={store}>{children}</Provider>;
-};
+}


### PR DESCRIPTION
## Summary
* Use only one variant when declaring functional components.

## Reason
* Consistent code throughout the codebase.
* Prefer functional components over `React.FC` to align with aligns with modern React patterns.