### PR TITLE
feat(home-mock-router): add home's test by testing a mocked router

### DIFF
--- a/src/__test__/Renderer.tsx
+++ b/src/__test__/Renderer.tsx
@@ -1,7 +1,7 @@
 import type { RenderResult } from "~__test__/test-utils";
 import { render as _render } from "~__test__/test-utils";
 import MuiThemeProvider from "~app/muiThemeProvider/MuiThemeProvider";
-import { TranslationProvider } from "~i18n";
+import { TestTranslationProvider } from "~i18n";
 
 import type { ComponentType } from "react";
 import type { ReactElement } from "react";
@@ -14,7 +14,7 @@ export class Renderer {
   }
 
   public withTranslation(): this {
-    return this.withProvider(TranslationProvider);
+    return this.withProvider(TestTranslationProvider);
   }
 
   public withThemeProvider(): this {

--- a/src/__test__/home.spec.tsx
+++ b/src/__test__/home.spec.tsx
@@ -2,6 +2,11 @@ import { Renderer } from "~__test__/Renderer";
 import type { RenderResult } from "~__test__/test-utils";
 import { userEvent } from "~__test__/test-utils";
 import HomePage from "~app/page";
+import txKeys from "~i18n/translations";
+
+enum Constants {
+  bgImageUrl = "/assets/svg/background.svg",
+}
 
 const mockRouter = jest.fn();
 jest.mock("next/navigation", () => ({
@@ -10,9 +15,16 @@ jest.mock("next/navigation", () => ({
   }),
 }));
 
-enum Constants {
-  bgImageUrl = "/assets/svg/background.svg",
-}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock("react-i18next", () => ({
+  ...jest.requireActual("react-i18next"),
+  useTranslation: () => {
+    return {
+      // eslint-disable-next-line id-length
+      t: (str: string) => str,
+    };
+  },
+}));
 
 describe("Landing page home component", () => {
   it("should be have one `div` with className 'landing'", () => {
@@ -28,10 +40,10 @@ describe("Landing page home component", () => {
     expect(landing[0]).toHaveStyle(`background-image: url(${Constants.bgImageUrl})`);
   });
 
-  it("should call mockRouter.push with 'signin' when the 'Sign In' button was pressed", async () => {
+  it("should call mockRouter with 'signin' when the 'Sign In' button was pressed", async () => {
     const homePage = renderHomePage();
     // this should use txKeys and not a hardcoded value
-    const signInButton = homePage.getByRole("button", { name: "S'inscrire" });
+    const signInButton = homePage.getByRole("button", { name: txKeys.home.buttons.join });
     expect(signInButton).not.toBeNull();
     await userEvent.click(signInButton);
     expect(mockRouter).toHaveBeenCalledWith("/signin");

--- a/src/__test__/home.spec.tsx
+++ b/src/__test__/home.spec.tsx
@@ -1,31 +1,43 @@
-import MuiThemeProvider from "~app/muiThemeProvider/MuiThemeProvider";
+import { Renderer } from "~__test__/Renderer";
+import type { RenderResult } from "~__test__/test-utils";
+import { userEvent } from "~__test__/test-utils";
 import HomePage from "~app/page";
 
-import { render } from "./test-utils";
+const mockRouter = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockRouter,
+  }),
+}));
 
-jest.mock("next/navigation");
-
-const bgImageUrl = "/assets/svg/background.svg";
+enum Constants {
+  bgImageUrl = "/assets/svg/background.svg",
+}
 
 describe("Landing page home component", () => {
   it("should be have one `div` with className 'landing'", () => {
-    const { container } = render(
-      <MuiThemeProvider>
-        <HomePage />
-      </MuiThemeProvider>,
-    );
+    const { container } = renderHomePage();
     const landing = container.getElementsByClassName("landing");
     expect(landing.length).toBe(1);
     expect(landing[0]?.tagName).toBe("DIV");
   });
 
-  it(`should be have a background image with the url '${bgImageUrl}'`, () => {
-    const { container } = render(
-      <MuiThemeProvider>
-        <HomePage />
-      </MuiThemeProvider>,
-    );
+  it(`should be have a background image with the url '${Constants.bgImageUrl}'`, () => {
+    const { container } = renderHomePage();
     const landing = container.getElementsByClassName("landing");
-    expect(landing[0]).toHaveStyle(`background-image: url(${bgImageUrl})`);
+    expect(landing[0]).toHaveStyle(`background-image: url(${Constants.bgImageUrl})`);
   });
+
+  it("should call mockRouter.push with 'signin' when the 'Sign In' button was pressed", async () => {
+    const homePage = renderHomePage();
+    // TODO: this should use txKeys and not a hardcoded value
+    const signInButton = homePage.getByRole("button", { name: "S'inscrire" });
+    expect(signInButton).not.toBeNull();
+    await userEvent.click(signInButton);
+    expect(mockRouter).toHaveBeenCalledWith("/signin");
+  });
+
+  function renderHomePage(): RenderResult {
+    return new Renderer(<HomePage />).withAllProviders().render();
+  }
 });

--- a/src/__test__/home.spec.tsx
+++ b/src/__test__/home.spec.tsx
@@ -30,7 +30,7 @@ describe("Landing page home component", () => {
 
   it("should call mockRouter.push with 'signin' when the 'Sign In' button was pressed", async () => {
     const homePage = renderHomePage();
-    // TODO: this should use txKeys and not a hardcoded value
+    // this should use txKeys and not a hardcoded value
     const signInButton = homePage.getByRole("button", { name: "S'inscrire" });
     expect(signInButton).not.toBeNull();
     await userEvent.click(signInButton);

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -17,10 +17,10 @@ export default function Home(): JSX.Element {
   const router = useRouter();
 
   const handleJoinClick = () => {
-    router.push("/signup");
+    router.push("/signin");
   };
   const handleSigninClick = () => {
-    router.push("/signin");
+    router.push("/signup");
   };
 
   return (


### PR DESCRIPTION
## Summary
- add home's test by testing a mocked router.
- use `TestTranslationProvider` instead of `TranslationProvider`.
this fixes:
``` 
console.error
    Warning: An update to TransactionProvider inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
``` 

## Trello Card
- Closes [TC#7](https://trello.com/c/EXuKGoaR/7-1-etq-dev-je-r%C3%A9dige-un-test-pour-composant-home)

