### PR TITLE
test: `TextInput` renders with correct value

### DIFF
--- a/src/components/textInput/TextInput.spec.tsx
+++ b/src/components/textInput/TextInput.spec.tsx
@@ -13,7 +13,6 @@ describe("TextInput component", () => {
   let textInputElement: HTMLElement;
 
   beforeEach(() => {
-    jest.clearAllMocks();
     const textInputRenderResult = new Renderer(<TextInput {...defaultProps} />).withAllProviders().render();
     expect(textInputRenderResult).not.toBeNull();
     textInputElement = textInputRenderResult.getByLabelText(defaultProps.label);

--- a/src/components/textInput/TextInput.spec.tsx
+++ b/src/components/textInput/TextInput.spec.tsx
@@ -14,7 +14,6 @@ describe("TextInput component", () => {
 
   beforeEach(() => {
     const textInputRenderResult = new Renderer(<TextInput {...defaultProps} />).withAllProviders().render();
-    expect(textInputRenderResult).not.toBeNull();
     textInputElement = textInputRenderResult.getByLabelText(defaultProps.label);
   });
 

--- a/src/components/textInput/TextInput.spec.tsx
+++ b/src/components/textInput/TextInput.spec.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+import { Renderer } from "~__test__/Renderer";
+import TextInput from "~components/textInput/TextInput";
+
+describe("TextInput component", () => {
+  const defaultProps = {
+    type: "test",
+    label: "test",
+    value: "test",
+  };
+
+  let textInputElement: HTMLElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const textInputRenderResult = new Renderer(<TextInput {...defaultProps} />).withAllProviders().render();
+    expect(textInputRenderResult).not.toBeNull();
+    textInputElement = textInputRenderResult.getByLabelText(defaultProps.label);
+  });
+
+  it("should be in the DOM", () => {
+    expect(textInputElement).toBeInTheDocument();
+  });
+
+  it("should render with the provided props", () => {
+    expect(textInputElement).toHaveAttribute("type", defaultProps.type);
+    expect(textInputElement).toHaveValue(defaultProps.value);
+  });
+});


### PR DESCRIPTION
## Summary
- add simple tests for `TextInput` component.

## Trello Card
- Closes [TC#3](https://trello.com/c/L5ZB4xpu/3-2-etq-dev-je-cr%C3%A9e-un-test-pour-le-composant-g%C3%A9n%C3%A9rique-textinput)