### PR TITLE
feat: add back button component to signin page

### DIFF
--- a/src/app/signin/layout.tsx
+++ b/src/app/signin/layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import AuthImage from "~components/authImage/AuthImage";
+import { BackButton } from "~components/backButton";
 import { SignInForm } from "~components/signInForm/SignInForm";
 
 import { Grid } from "@mui/material";
@@ -25,13 +26,24 @@ export default function SignInPage(): JSX.Element {
         xs={12}
         md={6}
         sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
+          position: "relative",
           bgcolor: "background.paper",
+          minHeight: "100vh",
         }}
       >
-        <SignInForm />
+        <BackButton url={"/"} />
+
+        <Grid
+          container
+          sx={{
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <SignInForm />
+        </Grid>
       </Grid>
     </Grid>
   );

--- a/src/components/backButton/BackButton.spec.tsx
+++ b/src/components/backButton/BackButton.spec.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+import { Renderer } from "~__test__/Renderer";
+import { userEvent } from "~__test__/test-utils";
+import { BackButton } from "~components/backButton/BackButton";
+
+const mockRouter = {
+  push: jest.fn(),
+};
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+}));
+
+describe("back button tests", () => {
+  const defaultProps = {
+    url: "/",
+  };
+
+  let backButton: HTMLElement;
+
+  beforeEach(() => {
+    const result = new Renderer(<BackButton {...defaultProps} />).withAllProviders().render();
+    backButton = result.getByRole("button");
+  });
+
+  it("should render the back button", () => {
+    expect(backButton).toBeInTheDocument();
+  });
+
+  it("should navigate to url when clicked", async () => {
+    const user = userEvent.setup();
+
+    await user.click(backButton);
+    expect(mockRouter.push).toBeCalledWith(defaultProps.url);
+  });
+});

--- a/src/components/backButton/BackButton.style.ts
+++ b/src/components/backButton/BackButton.style.ts
@@ -1,0 +1,29 @@
+import { LeftArrowSvg } from "~components/svg/LeftArrowSvg";
+
+import { Button, Stack, styled, Typography } from "@mui/material";
+
+export const StyledButton = styled(Button)(({ theme }) => ({
+  color: theme.palette.grey["600"],
+  padding: 0,
+  minWidth: "auto",
+  "&:hover": {
+    color: theme.palette.grey["900"],
+    backgroundColor: "transparent",
+  },
+}));
+
+export const StyledStack = styled(Stack)({
+  display: "flex",
+  alignItems: "center",
+});
+
+export const StyledTypography = styled(Typography)(({ theme }) => ({
+  color: "white",
+  fontSize: theme.typography.label.fontSize,
+  lineHeight: theme.typography.label.lineHeight,
+  textTransform: "none",
+}));
+
+export const StyledLeftArrowSvg = styled(LeftArrowSvg)(({ theme }) => ({
+  fontSize: theme.typography.headline.fontSize,
+}));

--- a/src/components/backButton/BackButton.tsx
+++ b/src/components/backButton/BackButton.tsx
@@ -1,0 +1,34 @@
+import {
+  StyledButton,
+  StyledLeftArrowSvg,
+  StyledStack,
+  StyledTypography,
+} from "~components/backButton/BackButton.style";
+import TranslateMessage from "~i18n/TranslateMessage";
+import txKeys from "~i18n/translations";
+
+import { useRouter } from "next/navigation";
+
+interface BackButtonProps {
+  url: string;
+}
+
+export function BackButton({ url }: BackButtonProps): JSX.Element {
+  const router = useRouter();
+
+  return (
+    <StyledButton
+      variant="text"
+      onClick={() => {
+        router.push(url);
+      }}
+    >
+      <StyledStack direction="column">
+        <StyledLeftArrowSvg />
+        <StyledTypography variant="caption">
+          <TranslateMessage txKey={txKeys.common.back} />
+        </StyledTypography>
+      </StyledStack>
+    </StyledButton>
+  );
+}

--- a/src/components/backButton/index.ts
+++ b/src/components/backButton/index.ts
@@ -1,0 +1,1 @@
+export { BackButton } from "./BackButton";

--- a/src/components/signInForm/SignInForm.style.tsx
+++ b/src/components/signInForm/SignInForm.style.tsx
@@ -1,6 +1,6 @@
-import { EyeIconSvg } from "~components/eyeIcon/EyeIconSvg";
 import { PrimaryButton } from "~components/primaryButton";
 import { SecondaryButton } from "~components/secondaryButton";
+import { EyeIconSvg } from "~components/svg/EyeIconSvg";
 
 import { Box, styled } from "@mui/material";
 

--- a/src/components/svg/EyeIconSvg.tsx
+++ b/src/components/svg/EyeIconSvg.tsx
@@ -6,15 +6,15 @@ export function EyeIconSvg({ ...props }: SVGProps<SVGSVGElement>): JSX.Element {
       <g clip-path="url(#clip0_32605_398)">
         <path
           d="M0.833496 9.99999C0.833496 9.99999 4.16683 3.33333 10.0002 3.33333C15.8335 3.33333 19.1668 9.99999 19.1668 9.99999C19.1668 9.99999 15.8335 16.6667 10.0002 16.6667C4.16683 16.6667 0.833496 9.99999 0.833496 9.99999Z"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
         <path
           d="M10 12.5C11.3807 12.5 12.5 11.3807 12.5 10C12.5 8.61929 11.3807 7.5 10 7.5C8.61929 7.5 7.5 8.61929 7.5 10C7.5 11.3807 8.61929 12.5 10 12.5Z"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
       </g>
       <defs>

--- a/src/components/svg/LeftArrowSvg.tsx
+++ b/src/components/svg/LeftArrowSvg.tsx
@@ -1,0 +1,8 @@
+export function LeftArrowSvg(): JSX.Element {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M19 12H5" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M12 19L5 12L12 5" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -4,7 +4,8 @@
     "labelExample": "text example",
     "labelExampleFormatted": "example <underline>formatted</underline> text",
     "generalError": "An error has occurred",
-    "styledButton": "Example of @emotion/styled button "
+    "styledButton": "Example of @emotion/styled button ",
+    "back": "Back"
   },
   "auth": {
     "welcomeBack": "Welcome back",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -4,7 +4,8 @@
     "labelExample": "example de texte",
     "labelExampleFormatted": "exemple de texte <underline>formaté</underline>",
     "generalError": "Une erreur s'est produite",
-    "styledButton": "Exemple de bouton @emotion/styled"
+    "styledButton": "Exemple de bouton @emotion/styled",
+    "back": "Retour"
   },
   "auth": {
     "welcomeBack": "Bienvenue à nouveau",


### PR DESCRIPTION
## Summary
- Add back-button to signin page with test coverage.

## Trello Card
- Closes [TC#31](https://trello.com/c/oA4nQuH4/31-1-etq-theodoer-sur-la-page-de-sign-in-quand-je-clique-sur-le-bouton-back-je-reviens-vers-la-page-daccueil)

## Figma Reference
- [Landing Page](https://www.figma.com/design/QC1LbA6qGVTWA3ZsbYvnHS/Theodo_Dojo?t=Uc1CVlA25vb3fqAm-0)

## Preview
* Signin page:
![image](https://github.com/user-attachments/assets/a0cdd69f-cf4b-41f7-b122-ddb58be374a8)
