### PR TITLE
feat: add prefilled email

### DIFF
--- a/src/components/signInForm/SignInForm.tsx
+++ b/src/components/signInForm/SignInForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import {
   LoginWithEmailButton,
@@ -9,6 +9,7 @@ import {
   ViewPasswordIcon,
 } from "~components/signInForm/SignInForm.style";
 import TextInput from "~components/textInput";
+import { useGlobalStorage } from "~hooks/globalStorage/useGlobalStorage";
 import TranslateMessage from "~i18n/TranslateMessage";
 import txKeys from "~i18n/translations";
 import { useTranslation } from "~i18n/useTranslation";
@@ -18,12 +19,25 @@ import AppleIcon from "@mui/icons-material/Apple";
 import GoogleIcon from "@mui/icons-material/Google";
 import { Box, Container, IconButton, InputAdornment, Link, Stack, Typography, useTheme } from "@mui/material";
 import Image from "next/image";
+import { useSearchParams } from "next/navigation";
 import theodoLogo from "public/assets/theodo.png";
 
 export function SignInForm(): JSX.Element {
-  const [passwordShow, setPasswordShow] = useState(false);
+  const searchParams = useSearchParams();
+  const globalStorage = useGlobalStorage();
   const translate = useTranslation();
   const theme = useTheme();
+
+  const [passwordShow, setPasswordShow] = useState(false);
+  const [email, setEmail] = useState("");
+
+  useEffect(() => {
+    const prefilled = searchParams?.get("prefilled");
+    if (prefilled === "true") {
+      const lastEmail = globalStorage.email.get();
+      if (lastEmail !== null) setEmail(lastEmail);
+    }
+  }, [globalStorage.email, searchParams]);
 
   return (
     <Container maxWidth="sm">
@@ -40,7 +54,13 @@ export function SignInForm(): JSX.Element {
         {/* Form */}
         <Box component="form" width="100%">
           <Stack spacing={3}>
-            <TextInput fullWidth label={translate(txKeys.auth.emailAddress)} variant="standard" autoComplete="email" />
+            <TextInput
+              fullWidth
+              label={translate(txKeys.auth.emailAddress)}
+              variant="standard"
+              autoComplete="email"
+              value={email}
+            />
 
             <TextInput
               label={translate(txKeys.auth.password)}

--- a/src/schemas/useGlobalStorage.ts
+++ b/src/schemas/useGlobalStorage.ts
@@ -2,5 +2,6 @@ import { z } from "zod";
 
 export const GlobalStorageSchema = z.object({
   userName: z.string().nullable(),
+  email: z.string().nullable(),
 });
 export type GlobalStorageType = z.infer<typeof GlobalStorageSchema>;


### PR DESCRIPTION
## Summary
- Add `email` field to `zodStorage`
- Prefill `email` if it exists in the local storage.

## Trello Card
- Closes [TC#30](https://trello.com/c/g6Oq1dBm/30-3-etq-theodoer-sur-la-page-de-sign-in-je-veux-voir-le-formulaire-dauthentification)

## Figma Reference
- [Landing Page](https://www.figma.com/design/QC1LbA6qGVTWA3ZsbYvnHS/Theodo_Dojo?t=Uc1CVlA25vb3fqAm-0)

## Preview
* Signin page:
![Screenshot 2025-03-10 152129](https://github.com/user-attachments/assets/9fa755df-686b-42c3-9796-2d6cbbbaacd6)
![Screenshot 2025-03-10 152136](https://github.com/user-attachments/assets/28512324-110e-4f91-b446-dc55514b194f)
