### PR TITLE
test: add tests for email and password schema validation

### DIFF
--- a/src/schemas/SigninFormSchema.constants.ts
+++ b/src/schemas/SigninFormSchema.constants.ts
@@ -1,0 +1,8 @@
+export const SigninFormatConstants = {
+  noEmailInput: "L'email est obligatoire",
+  notanEmail: "Format d'email invalide",
+  notaTheodoEmail: "L'email doit être @theodo.com",
+
+  noPasswordInput: "Le mot de passe est obligatoire",
+  notaValidPassword: "Le mot de passe doit contenir au moins 4 caractères",
+};

--- a/src/schemas/SigninFormSchema.test.ts
+++ b/src/schemas/SigninFormSchema.test.ts
@@ -1,0 +1,70 @@
+import { SigninFormSchema } from "~schemas/SigninFormSchema";
+import { SigninFormatConstants } from "~schemas/SigninFormSchema.constants";
+
+describe("Login Validation Schema", () => {
+  it("should detect missing email", () => {
+    const invalidData = {
+      email: "",
+      password: "validPassword123",
+    };
+
+    const result = SigninFormSchema.safeParse(invalidData);
+    expect(result.success).toBe(false);
+
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(SigninFormatConstants.noEmailInput);
+    }
+  });
+
+  it("should detect invalid email domain", () => {
+    const invalidData = {
+      email: "test@gmail.com",
+      password: "validPassword123",
+    };
+
+    const result = SigninFormSchema.safeParse(invalidData);
+    expect(result.success).toBe(false);
+
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(SigninFormatConstants.notaTheodoEmail);
+    }
+  });
+
+  it("should detect missing password", () => {
+    const invalidData = {
+      email: "valid@theodo.com",
+      password: "",
+    };
+
+    const result = SigninFormSchema.safeParse(invalidData);
+    expect(result.success).toBe(false);
+
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(SigninFormatConstants.noPasswordInput);
+    }
+  });
+
+  it("should detect short password", () => {
+    const invalidData = {
+      email: "valid@theodo.com",
+      password: "123",
+    };
+
+    const result = SigninFormSchema.safeParse(invalidData);
+    expect(result.success).toBe(false);
+
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(SigninFormatConstants.notaValidPassword);
+    }
+  });
+
+  it("should validate correct credentials", () => {
+    const validData = {
+      email: "valid@theodo.com",
+      password: "validPassword123",
+    };
+
+    const result = SigninFormSchema.safeParse(validData);
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/schemas/SigninFormSchema.ts
+++ b/src/schemas/SigninFormSchema.ts
@@ -1,16 +1,15 @@
+import { SigninFormatConstants } from "~schemas/SigninFormSchema.constants";
+
 import { z } from "zod";
 
 export const SigninFormSchema = z.object({
   email: z
     .string()
-    .min(1, "L'email est obligatoire")
-    .email("Format d'email invalide")
-    .refine((val) => val.endsWith("@theodo.com"), "L'email doit être @theodo.com"),
+    .min(1, SigninFormatConstants.noEmailInput)
+    .email(SigninFormatConstants.notanEmail)
+    .refine((val) => val.endsWith("@theodo.com"), SigninFormatConstants.notaTheodoEmail),
 
-  password: z
-    .string()
-    .min(1, "Le mot de passe est obligatoire")
-    .min(4, "Le mot de passe doit contenir au moins 4 caractères"),
+  password: z.string().min(1, SigninFormatConstants.noPasswordInput).min(4, SigninFormatConstants.notaValidPassword),
 });
 
 export type SigninFormType = z.infer<typeof SigninFormSchema>;


### PR DESCRIPTION
## Summary
- Add tests for the newly added `email` and `password` schemas.

## Trello Card
- Closes [TC#15](https://trello.com/c/jNvtPGwb/15-1-etq-dev-je-r%C3%A9dige-un-test-pour-la-validation-zod)

## Figma Reference
- [Landing Page](https://www.figma.com/design/QC1LbA6qGVTWA3ZsbYvnHS/Theodo_Dojo?t=Uc1CVlA25vb3fqAm-0)

